### PR TITLE
Add multi-dataset support

### DIFF
--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import re
+import shutil
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -24,15 +25,73 @@ class Material:
 
 BASE_DIR = os.path.dirname(__file__)
 
+# Root directory where user game system data is stored
+DATASET_ROOT = os.path.join(os.path.expanduser("~"), "documents", "UniversalLootGen")
+
+# Currently selected game system directory
+_current_system_dir: Optional[str] = None
+
+
+def get_dataset_root() -> str:
+    """Return the base directory for all game system datasets."""
+    return DATASET_ROOT
+
+
+def list_game_systems() -> List[str]:
+    """Return available game system names."""
+    if not os.path.isdir(DATASET_ROOT):
+        return []
+    return [name for name in os.listdir(DATASET_ROOT) if os.path.isdir(os.path.join(DATASET_ROOT, name))]
+
+
+def ensure_game_system(name: str) -> str:
+    """Ensure the named game system directory exists with default data."""
+    system_dir = os.path.join(DATASET_ROOT, name)
+    if not os.path.isdir(system_dir):
+        os.makedirs(system_dir, exist_ok=True)
+        for fname in ("loot_items.json", "materials.json", "presets.json"):
+            shutil.copy(_resolve(f"data/{fname}"), os.path.join(system_dir, fname))
+    return system_dir
+
+
+def rename_game_system(old: str, new: str) -> None:
+    """Rename a game system directory."""
+    old_path = os.path.join(DATASET_ROOT, old)
+    new_path = os.path.join(DATASET_ROOT, new)
+    if os.path.isdir(old_path) and old != new:
+        os.rename(old_path, new_path)
+
+
+def set_game_system(name: Optional[str]) -> None:
+    """Set the currently active game system."""
+    global _current_system_dir
+    if name:
+        _current_system_dir = ensure_game_system(name)
+    else:
+        _current_system_dir = None
+
+
+def get_current_system_dir() -> Optional[str]:
+    return _current_system_dir
+
+
+def get_data_path(filename: str) -> str:
+    """Return absolute path for ``filename`` within the active dataset."""
+    if _current_system_dir:
+        return os.path.join(_current_system_dir, filename)
+    return _resolve(f"data/{filename}")
+
 
 def _resolve(path: str) -> str:
     """Return absolute path relative to this module."""
     return os.path.join(BASE_DIR, path)
 
 
-def load_materials(filepath=_resolve('data/materials.json')) -> List[Material]:
+def load_materials(filepath: Optional[str] = None) -> List[Material]:
     """Load material definitions from json file."""
-    path = _resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath
+    path = filepath or get_data_path('materials.json')
+    if not os.path.isabs(path):
+        path = _resolve(path)
     if not os.path.exists(path):
         return []
     with open(path, 'r') as file:
@@ -41,20 +100,25 @@ def load_materials(filepath=_resolve('data/materials.json')) -> List[Material]:
     return [Material(**m) for m in materials_data]
 
 
-def save_materials(materials: List[Material], filepath=_resolve('data/materials.json')) -> None:
+def save_materials(materials: List[Material], filepath: Optional[str] = None) -> None:
     """Save material definitions to json file."""
-    path = _resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath
+    path = filepath or get_data_path('materials.json')
+    if not os.path.isabs(path):
+        path = _resolve(path)
     with open(path, 'w') as file:
         json.dump({"materials": [m.__dict__ for m in materials]}, file, indent=4)
 
 
-def load_loot_items(filepath=_resolve('data/loot_items.json')):
+def load_loot_items(filepath: Optional[str] = None):
     """Load loot items from json file.
 
     The file may contain either a list of items or an object with
     ``items`` and ``tags`` keys. Only the item data is returned here.
     """
-    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'r') as file:
+    path = filepath or get_data_path('loot_items.json')
+    if not os.path.isabs(path):
+        path = _resolve(path)
+    with open(path, 'r') as file:
         data = json.load(file)
 
     if isinstance(data, dict):
@@ -64,13 +128,16 @@ def load_loot_items(filepath=_resolve('data/loot_items.json')):
 
     return [LootItem(**item) for item in items_data]
 
-def load_all_tags(filepath=_resolve('data/loot_items.json')):
+def load_all_tags(filepath: Optional[str] = None):
     """Return the list of all tags stored in ``loot_items.json``.
 
     For backward compatibility, if the file does not contain a ``tags``
     key the tags are derived from the items.
     """
-    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'r') as file:
+    path = filepath or get_data_path('loot_items.json')
+    if not os.path.isabs(path):
+        path = _resolve(path)
+    with open(path, 'r') as file:
         data = json.load(file)
 
     if isinstance(data, dict) and "tags" in data:
@@ -81,12 +148,18 @@ def load_all_tags(filepath=_resolve('data/loot_items.json')):
     tags = sorted({tag for item in items for tag in item.get("tags", [])})
     return tags
 
-def load_presets(filepath=_resolve('data/presets.json')):
-    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'r') as file:
+def load_presets(filepath: Optional[str] = None):
+    path = filepath or get_data_path('presets.json')
+    if not os.path.isabs(path):
+        path = _resolve(path)
+    with open(path, 'r') as file:
         return json.load(file)
 
-def save_presets(presets, filepath=_resolve('data/presets.json')):
-    with open(_resolve(filepath) if isinstance(filepath, str) and not os.path.isabs(filepath) else filepath, 'w') as file:
+def save_presets(presets, filepath: Optional[str] = None):
+    path = filepath or get_data_path('presets.json')
+    if not os.path.isabs(path):
+        path = _resolve(path)
+    with open(path, 'w') as file:
         json.dump(presets, file, indent=4)
 
 def generate_loot(


### PR DESCRIPTION
## Summary
- add dataset management utilities
- add game system selection dialog
- allow switching datasets from menu
- load/save data to selected dataset folder

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867f933d1c08329b0b5b74e22b0c150