### PR TITLE
Add double click selection for game systems

### DIFF
--- a/loot_generator/loot_app.pyw
+++ b/loot_generator/loot_app.pyw
@@ -53,7 +53,7 @@ def select_game_system(root=None) -> str:
             rename_game_system(old, new)
             refresh()
 
-    def choose():
+    def choose(event=None):
         sel = listbox.curselection()
         if not sel:
             messagebox.showerror("Error", "Select a game system.", parent=win)
@@ -64,6 +64,9 @@ def select_game_system(root=None) -> str:
     ttk.Button(win, text="New", command=create).grid(row=1, column=0, padx=5, pady=5)
     ttk.Button(win, text="Rename", command=rename).grid(row=1, column=1, padx=5, pady=5)
     ttk.Button(win, text="Select", command=choose).grid(row=1, column=2, padx=5, pady=5)
+
+    # Allow double clicking on a system to select it
+    listbox.bind("<Double-1>", choose)
 
     for i in range(3):
         win.columnconfigure(i, weight=1)


### PR DESCRIPTION
## Summary
- allow choosing a game system by double clicking in the selection dialog

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686803d103ec83299b9c8ad9d1f0c0d4