### PR TITLE
Improve README item and material sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ one item per line as `name|rarity|description|point_value|tag1,tag2`. All added
 items are saved to `loot_items.json` and become available for future loot
 generation.
 
+When adding a single item the form asks for the same fields individually.
+`Rarity` and `Point Value` must be integers while `Tags` are entered as a
+comma‑separated list. The `Name` field may contain material placeholders such
+as `[Metal]` or `[Stone/o]` which are resolved using the materials list when
+loot is generated. For example, entering `[Metal] Dagger` with rarity `3`,
+description `Sturdy blade`, value `10` and tags `weapon,melee` could create an
+"Iron Dagger" if a material named "Iron" exists.
+
 ## Managing Materials
 
 Some item names may include placeholders such as `[Metal]` or `[Stone/o]` which
@@ -58,3 +66,10 @@ Material**, **Bulk Add Materials** and **Delete Material** actions. Optional
 placeholders denoted with `/o` may resolve to an empty string, allowing items
 like `[Metal] [Stone/o] Earring` or `[Wood/Metal/o] Shield` to generate with or
 without the material name.
+
+The single **Add Material** dialog accepts a `Name`, numeric `Modifier`, and
+`Type`. `Modifier` is a multiplier applied to an item's point value when the
+material is used. `Type` must match one of the placeholder categories above.
+For example entering `Steel` with a modifier of `1.2` and type `Metal` allows a
+placeholder like `[Metal] Sword` to produce `Steel Sword` valued at 20% higher
+than the base item.


### PR DESCRIPTION
## Summary
- clarify Add Item fields
- document Add Material form and examples

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682b1cb6c0832996273159369c8159