### PR TITLE
Add item size and period options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ a preset, or **Delete Preset** to remove it.
 
 Use the **Items** tab to manage loot items. Click **Add Item** for a single
 entry or **Bulk Add Items** to paste many at once. Existing entries can be
-modified with **Edit Item** or removed with **Delete Item**. In bulk mode, enter
-one item per line as `name|rarity|description|point_value|tag1,tag2`. All added
+ modified with **Edit Item** or removed with **Delete Item**. In bulk mode, enter
+one item per line as `name|rarity|description|point_value|tag1,tag2|size|period`. All added
 items are saved to `loot_items.json` and become available for future loot
 generation.
+
+Valid sizes are `tiny`, `small`, `midsize`, `large` and `huge`. Valid time
+periods are `tribal`, `medieval`, `modern`, `postmodern` and `spacer`.
 
 ## Managing Materials
 

--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -6,6 +6,10 @@ import shutil
 from dataclasses import dataclass
 from typing import List, Optional
 
+# Supported sizes and time periods in increasing order
+SIZES = ["tiny", "small", "midsize", "large", "huge"]
+PERIODS = ["tribal", "medieval", "modern", "postmodern", "spacer"]
+
 @dataclass
 class LootItem:
     name: str
@@ -13,6 +17,8 @@ class LootItem:
     description: str
     point_value: int
     tags: List[str]
+    size: str = "midsize"
+    period: str = "modern"
 
 
 @dataclass
@@ -126,7 +132,21 @@ def load_loot_items(filepath: Optional[str] = None):
     else:
         items_data = data
 
-    return [LootItem(**item) for item in items_data]
+    loaded_items = []
+    for item in items_data:
+        loaded_items.append(
+            LootItem(
+                item.get("name"),
+                item.get("rarity"),
+                item.get("description", ""),
+                item.get("point_value"),
+                item.get("tags", []),
+                item.get("size", "midsize"),
+                item.get("period", "modern"),
+            )
+        )
+
+    return loaded_items
 
 def load_all_tags(filepath: Optional[str] = None):
     """Return the list of all tags stored in ``loot_items.json``.
@@ -169,8 +189,11 @@ def generate_loot(
     exclude_tags: Optional[List[str]] = None,
     min_rarity: Optional[int] = None,
     max_rarity: Optional[int] = None,
+    max_size: Optional[str] = None,
+    periods: Optional[List[str]] = None,
     materials: Optional[List[Material]] = None,
 ):
+    """Generate a list of ``LootItem`` objects matching the given filters."""
     if points <= 0:
         raise ValueError("points must be positive")
     filtered_items = [
@@ -180,6 +203,11 @@ def generate_loot(
         and (not exclude_tags or not set(exclude_tags).intersection(item.tags))
         and (min_rarity is None or item.rarity >= min_rarity)
         and (max_rarity is None or item.rarity <= max_rarity)
+        and (
+            max_size is None
+            or SIZES.index(item.size) <= SIZES.index(max_size)
+        )
+        and (periods is None or item.period in periods)
     ]
 
     # Validate rarities and skip items with non-positive values
@@ -217,7 +245,7 @@ def generate_loot(
         item = random.choices(available_items, weights=weights, k=1)[0]
         if materials:
             name, value = resolve_material_placeholders(item.name, item.point_value, materials)
-            item = LootItem(name, item.rarity, item.description, value, item.tags)
+            item = LootItem(name, item.rarity, item.description, value, item.tags, item.size, item.period)
         loot.append(item)
         total_points += item.point_value
 
@@ -259,8 +287,8 @@ def resolve_material_placeholders(name: str, value: int, materials: List[Materia
 def parse_items_text(text: str) -> List[LootItem]:
     """Parse a bulk text string into ``LootItem`` objects.
 
-    Each non-empty line should contain five ``|`` separated fields in the
-    order ``name|rarity|description|point_value|tag1,tag2``. Tags are
+    Each non-empty line should contain seven ``|`` separated fields in the
+    order ``name|rarity|description|point_value|tag1,tag2|size|period``. Tags are
     comma-separated. Whitespace around fields is ignored.
     """
 
@@ -269,13 +297,13 @@ def parse_items_text(text: str) -> List[LootItem]:
         if not line.strip():
             continue
         parts = [p.strip() for p in line.split("|")]
-        if len(parts) != 5:
-            raise ValueError("Each line must contain five '|' separated fields")
-        name, rarity_str, description, value_str, tags_str = parts
+        if len(parts) != 7:
+            raise ValueError("Each line must contain seven '|' separated fields")
+        name, rarity_str, description, value_str, tags_str, size, period = parts
         rarity = int(rarity_str)
         point_value = int(value_str)
         tags = [t.strip() for t in tags_str.split(",") if t.strip()]
-        items.append(LootItem(name, rarity, description, point_value, tags))
+        items.append(LootItem(name, rarity, description, point_value, tags, size, period))
 
     return items
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,7 +110,7 @@ def test_generate_loot_invalid_point_values_raise():
 
 
 def test_parse_items_text_valid():
-    text = "Sword|1|Sharp blade|10|weapon,melee"
+    text = "Sword|1|Sharp blade|10|weapon,melee|midsize|modern"
     items = utils.parse_items_text(text)
     assert len(items) == 1
     item = items[0]


### PR DESCRIPTION
## Summary
- expand `LootItem` to include `size` and `period`
- support size and period filtering in `generate_loot`
- parse size and period in bulk item text
- extend GUI for size/period fields and generation filters
- document new fields in README
- adjust tests for new format

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682aa1fa6483298251279a97cea7a1