### PR TITLE
Allow fractional point values

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ generation.
 Valid sizes are `tiny`, `small`, `midsize`, `large` and `huge`. Valid time
 periods are `tribal`, `medieval`, `modern`, `postmodern` and `spacer`.
 When adding a single item the form asks for the same fields individually.
-`Rarity` and `Point Value` must be integers while `Tags` are entered as a
+`Rarity` must be an integer while `Point Value` can be a decimal number no less than `0.0001`. `Tags` are entered as a
 comma‑separated list. The `Name` field may contain material placeholders such
 as `[Metal]` or `[Stone/o]` which are resolved using the materials list when
 loot is generated. For example, entering `[Metal] Dagger` with rarity `3`,

--- a/loot_generator/loot_app.pyw
+++ b/loot_generator/loot_app.pyw
@@ -417,11 +417,14 @@ class LootGeneratorApp:
 
         def save_new_item():
             try:
+                pv = float(entries["Point Value"].get())
+                if pv < 0.0001:
+                    raise ValueError("Point Value must be at least 0.0001")
                 item = LootItem(
                     name=entries["Name"].get(),
                     rarity=int(entries["Rarity (numeric, higher is rarer)"].get()),
                     description=entries["Description"].get(),
-                    point_value=int(entries["Point Value"].get()),
+                    point_value=pv,
                     tags=[tag.strip() for tag in entries["Tags (comma-separated)"].get().split(',')],
                     size=entries["Size (tiny/small/midsize/large/huge)"].get() or "midsize",
                     period=entries["Period (tribal/medieval/modern/postmodern/spacer)"].get() or "modern",
@@ -472,7 +475,10 @@ class LootGeneratorApp:
                 item.name = entries["Name"].get()
                 item.rarity = int(entries["Rarity (numeric, higher is rarer)"].get())
                 item.description = entries["Description"].get()
-                item.point_value = int(entries["Point Value"].get())
+                pv = float(entries["Point Value"].get())
+                if pv < 0.0001:
+                    raise ValueError("Point Value must be at least 0.0001")
+                item.point_value = pv
                 item.tags = [t.strip() for t in entries["Tags (comma-separated)"].get().split(',') if t.strip()]
                 item.size = entries["Size (tiny/small/midsize/large/huge)"].get() or "midsize"
                 item.period = entries["Period (tribal/medieval/modern/postmodern/spacer)"].get() or "modern"

--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -15,7 +15,7 @@ class LootItem:
     name: str
     rarity: int
     description: str
-    point_value: int
+    point_value: float
     tags: List[str]
     size: str = "midsize"
     period: str = "modern"
@@ -139,7 +139,7 @@ def load_loot_items(filepath: Optional[str] = None):
                 item.get("name"),
                 item.get("rarity"),
                 item.get("description", ""),
-                item.get("point_value"),
+                float(item.get("point_value")),
                 item.get("tags", []),
                 item.get("size", "midsize"),
                 item.get("period", "modern"),
@@ -231,7 +231,7 @@ def generate_loot(
             )
 
     loot = []
-    total_points = 0
+    total_points = 0.0
 
     if not filtered_items:
         return loot
@@ -252,7 +252,7 @@ def generate_loot(
     return loot
 
 
-def resolve_material_placeholders(name: str, value: int, materials: List[Material]) -> (str, int):
+def resolve_material_placeholders(name: str, value: float, materials: List[Material]) -> (str, float):
     """Replace material placeholders in ``name`` using provided materials.
 
     Placeholders are of the form ``[Metal]`` or ``[Metal/o]``. Multiple material
@@ -280,7 +280,7 @@ def resolve_material_placeholders(name: str, value: int, materials: List[Materia
         return mat.name
 
     new_name = pattern.sub(repl, name)
-    new_value = int(round(value * modifiers))
+    new_value = round(value * modifiers, 4)
     return new_name.strip(), new_value
 
 
@@ -301,7 +301,9 @@ def parse_items_text(text: str) -> List[LootItem]:
             raise ValueError("Each line must contain seven '|' separated fields")
         name, rarity_str, description, value_str, tags_str, size, period = parts
         rarity = int(rarity_str)
-        point_value = int(value_str)
+        point_value = float(value_str)
+        if point_value < 0.0001:
+            raise ValueError("point_value must be at least 0.0001")
         tags = [t.strip() for t in tags_str.split(",") if t.strip()]
         items.append(LootItem(name, rarity, description, point_value, tags, size, period))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,6 +127,12 @@ def test_parse_items_text_invalid():
         utils.parse_items_text(text)
 
 
+def test_parse_items_text_decimal_value():
+    text = "Gem|1|Shiny|0.5|misc|small|modern"
+    items = utils.parse_items_text(text)
+    assert items[0].point_value == 0.5
+
+
 def test_resolve_material_placeholders_required():
     materials = [utils.Material("Steel", 1.2, "Metal")]
     name, value = utils.resolve_material_placeholders("[Metal] Sword", 10, materials)


### PR DESCRIPTION
## Summary
- support decimal point values for loot items
- enforce minimum value of `0.0001`
- update GUI forms to handle decimal inputs
- document new requirement
- test decimal value parsing

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683a8fa5ec8329aaf09a271badfa7e