### PR TITLE
Add optional suffix support for materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ material of any listed type may be chosen. Materials are stored in
 Material**, **Bulk Add Materials** and **Delete Material** actions. Optional
 placeholders denoted with `/o` may resolve to an empty string, allowing items
 like `[Metal] [Stone/o] Earring` or `[Wood/Metal/o] Shield` to generate with or
-without the material name.
+without the material name. A suffix can be placed in parentheses to be included
+only when a material is used, e.g. `[Stone/o(-encrusted)]`.
 
 The single **Add Material** dialog accepts a `Name`, numeric `Modifier`, and
 `Type`. `Modifier` is a multiplier applied to an item's point value when the

--- a/loot_generator/utils.py
+++ b/loot_generator/utils.py
@@ -260,24 +260,24 @@ def resolve_material_placeholders(name: str, value: float, materials: List[Mater
     ``[Wood/Metal/Stone]``. The optional variant (``/o``) may be combined with
     multiple types (e.g. ``[Wood/Metal/o]``) and may be replaced with an empty
     string with 50% probability. ``value`` is modified by each material's
-    ``modifier``.
+    ``modifier``. A suffix can be supplied in parentheses which is appended when
+    a material is chosen, e.g. ``[Stone/o(-encrusted)]``.
     """
-    pattern = re.compile(r"\[([A-Za-z/]+?)(?:(/o))?\]")
+    pattern = re.compile(r"\[([A-Za-z/]+?)(?:(/o))?(?:\(([^\]]+)\))?\]")
     modifiers = 1.0
 
     def repl(match: re.Match) -> str:
         nonlocal modifiers
-        types_str, optional = match.group(1), match.group(2)
-        if optional:
-            if random.random() < 0.5:
-                return ""
+        types_str, optional, suffix = match.group(1), match.group(2), match.group(3)
+        if optional and random.random() < 0.5:
+            return ""
         types = [t.strip() for t in types_str.split("/") if t.strip()]
         options = [m for m in materials if m.type.lower() in {t.lower() for t in types}]
         if not options:
             return ""
         mat = random.choice(options)
         modifiers *= mat.modifier
-        return mat.name
+        return mat.name + (suffix or "")
 
     new_name = pattern.sub(repl, name)
     new_value = round(value * modifiers, 4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -195,3 +195,27 @@ def test_parse_materials_text_invalid():
     text = "Bad|data"
     with pytest.raises(ValueError):
         utils.parse_materials_text(text)
+
+
+def test_resolve_material_placeholders_suffix_required():
+    materials = [utils.Material("Gold", 1.0, "Metal")]
+    random.seed(0)
+    name, value = utils.resolve_material_placeholders("[Metal(-inlayed)] Ring", 5, materials)
+    assert name == "Gold-inlayed Ring"
+    assert value == 5
+
+
+def test_resolve_material_placeholders_optional_suffix_present():
+    materials = [utils.Material("Diamond", 1.5, "Stone")]
+    random.seed(0)
+    name, value = utils.resolve_material_placeholders("[Stone/o(-encrusted)] Ring", 10, materials)
+    assert name == "Diamond-encrusted Ring"
+    assert value == 15
+
+
+def test_resolve_material_placeholders_optional_suffix_absent():
+    materials = [utils.Material("Diamond", 1.5, "Stone")]
+    random.seed(1)
+    name, value = utils.resolve_material_placeholders("[Stone/o(-encrusted)] Ring", 10, materials)
+    assert name == "Ring"
+    assert value == 10


### PR DESCRIPTION
## Summary
- support suffix text in material placeholders like `[Stone/o(-encrusted)]`
- document the new placeholder syntax
- test required and optional placeholders with suffixes

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868416fdfa08329a6220fd73e8f71ac